### PR TITLE
prevent IndexError when examining tasks that don't have raw.xz outputs

### DIFF
--- a/fedimg/consumers.py
+++ b/fedimg/consumers.py
@@ -72,6 +72,7 @@ class KojiConsumer(fedmsg.consumers.FedmsgConsumer):
                 koji_session.getTaskResult(build)
             results = koji_session.multiCall()
             for result in results:
+                if not result: continue
                 url = get_rawxz_url(result[0])
                 if url:
                     rawxz_files.append(url)

--- a/fedimg/consumers.py
+++ b/fedimg/consumers.py
@@ -63,14 +63,19 @@ class KojiConsumer(fedmsg.consumers.FedmsgConsumer):
         # Get all of the .raw.xz URLs for the builds
         if len(builds) == 1:
             task_result = koji_session.getTaskResult(builds[0])
-            rawxz_files.append(get_rawxz_url(task_result))
+            url = get_rawxz_url(task_result)
+            if url:
+                rawxz_files.append(url)
         elif len(builds) >= 2:
             koji_session.multicall = True
             for build in builds:
                 koji_session.getTaskResult(build)
             results = koji_session.multiCall()
             for result in results:
-                rawxz_files.append(get_rawxz_url(result[0]))
+                url = get_rawxz_url(result[0])
+                if url:
+                    rawxz_files.append(url)
+
         # We only want to upload:
         # 64 bit: base, atomic, bigdata
         # Not uploading 32 bit, vagrant, experimental, or other images.

--- a/fedimg/util.py
+++ b/fedimg/util.py
@@ -47,9 +47,12 @@ def get_file_arch(file_name):
 def get_rawxz_url(task_result):
     """ Returns the URL of the raw.xz file produced by the Koji task whose
     output files are passed as a list via the task_result argument. """
-    # I think there might only ever be one qcow2 file per task,
-    # but doing it this way plays it safe.
-    file_name = [f for f in task_result['files'] if f.endswith('.raw.xz')][0]
+    # There should only be one item in this list
+    rawxz_list = [f for f in task_result['files'] if f.endswith('.raw.xz')]
+    if len(rawxz_list) < 1:
+        return None
+    file_name = rawxz_list[0]
+
     task_id = task_result['task_id']
 
     # extension to base URL to exact file directory


### PR DESCRIPTION
I had a big "do'h" moment just now and realized this will fix the IndexError error messages we've been seeing on fedimg machines. This should fix #23.