### PR TITLE
Feature/fix fedmsg meta

### DIFF
--- a/fedimg/messenger.py
+++ b/fedimg/messenger.py
@@ -27,7 +27,7 @@ https://github.com/fedora-infra/fedmsg_meta_fedora_infrastructure/blob/develop/f
 """
 
 
-def message(topic, image_url, dest, status, extra=None):
+def message(topic, image_url, dest, status, extra=dict()):
     """ Takes a message topic, image name, an upload destination (ex.
     "EC2-eu-west-1"), and a status (ex. "failed"). Can also take an optional
     dictionary of addiitonal bits of information, such as an AMI ID for an

--- a/fedimg/messenger.py
+++ b/fedimg/messenger.py
@@ -27,12 +27,14 @@ https://github.com/fedora-infra/fedmsg_meta_fedora_infrastructure/blob/develop/f
 """
 
 
-def message(topic, image_url, dest, status, extra=dict()):
+def message(topic, image_url, dest, status, extra=None):
     """ Takes a message topic, image name, an upload destination (ex.
     "EC2-eu-west-1"), and a status (ex. "failed"). Can also take an optional
     dictionary of addiitonal bits of information, such as an AMI ID for an
     image registered to AWS EC2. Emits a fedmsg appropriate
     for each image task (an upload or a test). """
+
+    extra = extra or dict()
 
     image_name = image_url.split('/')[-1].replace('.raw.xz', '')
 

--- a/fedimg/services/ec2.py
+++ b/fedimg/services/ec2.py
@@ -449,7 +449,10 @@ class EC2Service(object):
 
             # Alert the fedmsg bus that an image test has started
             fedimg.messenger.message('image.test', self.build_name,
-                                     self.destination, 'started')
+                                     self.destination, 'started',
+                                     extra={'id': self.images[0].id,
+                                            'virt_type': self.virt_type,
+                                            'vol_type': self.vol_type})
 
             client = paramiko.SSHClient()
             client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
@@ -471,6 +474,11 @@ class EC2Service(object):
             if chan.recv_exit_status() != 0:
                 # There was a problem with the SSH command
                 log.error('Problem testing new AMI')
+                fedimg.messenger.message('image.test', self.build_name,
+                                         self.destination, 'failed',
+                                         extra={'id': self.images[0].id,
+                                                'virt_type': self.virt_type,
+                                                'vol_type': self.vol_type})
                 raise EC2AMITestException("Tests on AMI failed.")
 
             client.close()

--- a/fedimg/services/ec2.py
+++ b/fedimg/services/ec2.py
@@ -427,7 +427,6 @@ class EC2Service(object):
 
             # Actually deploy the test instance
             self.test_node = driver.deploy_node(
-                # TODO: Test all images
                 name=name, image=self.images[0], size=size,
                 ssh_username=fedimg.AWS_TEST_USER,
                 ssh_alternate_usernames=['root'],
@@ -486,8 +485,6 @@ class EC2Service(object):
             log.info('AMI test completed')
             fedimg.messenger.message('image.test', self.build_name,
                                      self.destination, 'completed',
-                                     # TODO: Update this line when
-                                     # we test all images
                                      extra={'id': self.images[0].id,
                                             'virt_type': self.virt_type,
                                             'vol_type': self.vol_type})

--- a/fedimg/services/ec2.py
+++ b/fedimg/services/ec2.py
@@ -281,6 +281,8 @@ class EC2Service(object):
             if status != 0:
                 # There was a problem with the SSH command
                 log.error('Problem writing volume with utility instance')
+                fedimg.messenger.message('image.upload', self.build_name,
+                                         self.destination, 'failed')
                 raise EC2UtilityException("Problem writing image to"
                                           " utility instance volume."
                                           " Command exited with"
@@ -496,8 +498,6 @@ class EC2Service(object):
                     {'LaunchPermission.Add.1.Group': 'all'})
 
         except EC2UtilityException as e:
-            fedimg.messenger.message('image.upload', self.build_name,
-                                     self.destination, 'failed')
             log.exception("Failure")
             if fedimg.CLEAN_UP_ON_FAILURE:
                 self._clean_up(driver,
@@ -505,8 +505,6 @@ class EC2Service(object):
             return 1
 
         except EC2AMITestException as e:
-            fedimg.messenger.message('image.test', self.build_name,
-                                     self.destination, 'failed')
             log.exception("Failure")
             if fedimg.CLEAN_UP_ON_FAILURE:
                 self._clean_up(driver,
@@ -514,8 +512,6 @@ class EC2Service(object):
             return 1
 
         except DeploymentException as e:
-            fedimg.messenger.message('image.upload', self.build_name,
-                                     self.destination, 'failed')
             log.exception("Problem deploying node: {0}".format(e.value))
             if fedimg.CLEAN_UP_ON_FAILURE:
                 self._clean_up(driver,
@@ -524,8 +520,6 @@ class EC2Service(object):
 
         except Exception as e:
             # Just give a general failure message.
-            fedimg.messenger.message('image.upload', self.build_name,
-                                     self.destination, 'failed')
             log.exception("Unexpected exception")
             if fedimg.CLEAN_UP_ON_FAILURE:
                 self._clean_up(driver,

--- a/fedimg/services/ec2.py
+++ b/fedimg/services/ec2.py
@@ -398,6 +398,8 @@ class EC2Service(object):
             log.info('Completed image registration')
 
             # Emit success fedmsg
+            # TODO: Can probably move this into the above try/except,
+            # to avoid just dumping all the messages at once.
             for image in self.images:
                 fedimg.messenger.message('image.upload', self.build_name,
                                          self.destination, 'completed',


### PR DESCRIPTION
This should fix https://github.com/fedora-infra/fedmsg_meta_fedora_infrastructure/issues/268.
Short story: `extra` dict info wasn't being sent with the "started" and "failed" `image.test` fedmsgs. I can cut a new release with these fixes today.