### PR TITLE
This is always the last 4 digits.

### DIFF
--- a/fedimg/util.py
+++ b/fedimg/util.py
@@ -56,7 +56,7 @@ def get_rawxz_url(task_result):
     task_id = task_result['task_id']
 
     # extension to base URL to exact file directory
-    koji_url_extension = "/{}/{}".format(str(task_id)[3:], str(task_id))
+    koji_url_extension = "/{}/{}".format(str(task_id)[-4:], str(task_id))
     full_file_location = fedimg.BASE_KOJI_TASK_URL + koji_url_extension
 
     return full_file_location + "/{}".format(file_name)


### PR DESCRIPTION
This was originally written to use everything but the first 3 digits.
Which worked for a long while!  That is, until the task IDs grew into a new
order of magnitude and it stopped working.

fedimg has been trying to curl this:

https://kojipkgs.fedoraproject.org//work/tasks/17094/10617094/Fedora-Cloud-Base-23_Alpha-20150805.x86_64.raw.xz

when it should have been trying to curl this:

https://kojipkgs.fedoraproject.org//work/tasks/7094/10617094/Fedora-Cloud-Base-23_Alpha-20150805.x86_64.raw.xz