### PR TITLE
Rearrange image.test fedmsg alerts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docs/_build/
 
 # Config file (containing secret keys and whatnot)
 fedimg.cfg
+.eggs


### PR DESCRIPTION
First, tell the world that we are starting our test *before* we try to
deploy a node with our new AMI (in case that fails like it did today).

Second, if the deploy fails, then publish a second fedmsg message
indicating that our test fails (since we never even got to start the
"test" -- the node never came up).