### PR TITLE
Monkeypatch libcloud to give it support for the eu-central-1 ec2 region.

### DIFF
--- a/bin/trigger_upload.py
+++ b/bin/trigger_upload.py
@@ -25,6 +25,10 @@ if len(sys.argv) != 2:
 logging.config.dictConfig(fedmsg.config.load_config()['logging'])
 log = logging.getLogger('fedmsg')
 
+# Patch libcloud to give it support for the ec2 eu-central-1 region
+import fedimg.haxx
+fedimg.haxx.monkeypatch_libcloud()
+
 upload_pool = multiprocessing.pool.ThreadPool(processes=4)
 
 url = sys.argv[1]

--- a/fedimg/consumers.py
+++ b/fedimg/consumers.py
@@ -41,6 +41,10 @@ class KojiConsumer(fedmsg.consumers.FedmsgConsumer):
     config_key = 'kojiconsumer'
 
     def __init__(self, *args, **kwargs):
+        # Patch libcloud to give it support for the ec2 eu-central-1 region
+        import fedimg.haxx
+        fedimg.haxx.monkeypatch_libcloud()
+
         super(KojiConsumer, self).__init__(*args, **kwargs)
 
         # threadpool for upload jobs

--- a/fedimg/haxx.py
+++ b/fedimg/haxx.py
@@ -1,0 +1,69 @@
+# This file is part of fedimg.
+# Copyright (C) 2015 Red Hat, Inc.
+#
+# fedimg is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# fedimg is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public
+# License along with fedimg; if not, see http://www.gnu.org/licenses,
+# or write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+#
+# Authors:  Ralph Bean <rbean@redhat.com>
+#
+""" hacks.
+
+Primarily, this is used to monkeypatch libcloud at runtime to give it support
+for the ec2 eu-central-1 region which it amazingly doesn't have support for out
+of the box.  We have to define a driver for it and then inject our driver into
+its registry of providers.
+
+This needs to happen early on in the fedimg process... before
+fedimg.util.region_to_provider is invoked.
+
+"""
+
+import libcloud.compute.types
+import libcloud.compute.providers
+import libcloud.compute.drivers.ec2
+
+import logging
+log = logging.getLogger('fedmsg')
+
+
+class EC2EUCentralNodeDriver(libcloud.compute.drivers.ec2.EC2NodeDriver):
+    """
+    Driver class for EC2 in the EU Central Frankfurt region.
+    """
+    name = 'Amazon EC2 (eu-central-1)'
+    _region = 'eu-central-1'
+
+
+def monkeypatch_libcloud():
+    """ Call this to inject a eu-central-1 driver into libcloud's registry. """
+    key = 'ec2_eu_central'
+    if key in libcloud.compute.providers.DRIVERS:
+        log.info("libcloud now supports %r.  Not patching." % key)
+    else:
+        log.warn("monkey patching libcloud with support for %r" % key)
+        path = ('fedimg.haxx', 'EC2EUCentralNodeDriver')
+        libcloud.compute.types.Provider.EC2_EU_CENTRAL = key
+        libcloud.compute.providers.DRIVERS[key] = path
+
+
+if __name__ == '__main__':
+    logging.basicConfig()
+    monkeypatch_libcloud()
+
+    # A test...
+    import fedimg.util
+    provider = fedimg.util.region_to_provider('eu-central-1')
+    driver = libcloud.compute.providers.get_driver(provider)
+    print driver  # It works!

--- a/fedimg/util.py
+++ b/fedimg/util.py
@@ -80,6 +80,7 @@ def region_to_provider(region):
     providers = {'ap-northeast-1': Provider.EC2_AP_NORTHEAST,
                  'ap-southeast-1': Provider.EC2_AP_SOUTHEAST,
                  'ap-southeast-2': Provider.EC2_AP_SOUTHEAST2,
+                 'eu-central-1': Provider.EC2_EU_CENTRAL,  # See fedimg.haxx
                  'eu-west-1': Provider.EC2_EU_WEST,
                  'sa-east-1': Provider.EC2_SA_EAST,
                  'us-east-1': Provider.EC2_US_EAST,


### PR DESCRIPTION
This monkeypatches libcloud at runtime to give it support for the ec2 eu-central-1 region which it amazingly doesn't have support for out of the box.  We have to define a driver for it and then inject our driver into its registry of providers.

We call it from two places, where fedimg could possibly be starting up.
- From the consumer, for when fedimg is running in the background under the fedmsg-hub.
- From the trigger-upload script, for when fedimg is running manually in the foreground.
