### PR TITLE
Use new-style of accessing ec2 drivers.

### DIFF
--- a/fedimg/services/ec2.py
+++ b/fedimg/services/ec2.py
@@ -1,5 +1,5 @@
 # This file is part of fedimg.
-# Copyright (C) 2014 Red Hat, Inc.
+# Copyright (C) 2014-2015 Red Hat, Inc.
 #
 # fedimg is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -17,6 +17,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 # Authors:  David Gay <dgay@redhat.com>
+#           Ralph Bean <rbean@redhat.com>
 #
 
 import logging
@@ -35,7 +36,7 @@ from libcloud.compute.types import KeyPairDoesNotExistError
 import fedimg
 import fedimg.messenger
 from fedimg.util import get_file_arch
-from fedimg.util import region_to_provider, ssh_connection_works
+from fedimg.util import region_to_driver, ssh_connection_works
 
 
 class EC2ServiceException(Exception):
@@ -94,7 +95,7 @@ class EC2Service(object):
             attrs = line.strip().split('|')
 
             info = {'region': attrs[0],
-                    'prov': region_to_provider(attrs[0]),
+                    'driver': region_to_driver(attrs[0]),
                     'os': attrs[1],
                     'ver': attrs[2],
                     'arch': attrs[3],
@@ -163,7 +164,7 @@ class EC2Service(object):
 
         try:
             # Connect to the region through the appropriate libcloud driver
-            cls = get_driver(ami['prov'])
+            cls = ami['driver']
             driver = cls(fedimg.AWS_ACCESS_ID, fedimg.AWS_SECRET_KEY)
 
             # select the desired node attributes
@@ -578,7 +579,7 @@ class EC2Service(object):
 
                 # Connect to the libcloud EC2 driver for the region we
                 # want to copy into
-                alt_cls = get_driver(ami['prov'])
+                alt_cls = ami['driver']
                 alt_driver = alt_cls(fedimg.AWS_ACCESS_ID,
                                      fedimg.AWS_SECRET_KEY)
 
@@ -648,7 +649,7 @@ class EC2Service(object):
 
             for image in copied_images:
                 ami = self.test_amis[copied_images.index(image)]
-                alt_cls = get_driver(ami['prov'])
+                alt_cls = ami['driver']
                 alt_driver = alt_cls(fedimg.AWS_ACCESS_ID,
                                      fedimg.AWS_SECRET_KEY)
 

--- a/fedimg/util.py
+++ b/fedimg/util.py
@@ -1,5 +1,5 @@
 # This file is part of fedimg.
-# Copyright (C) 2014 Red Hat, Inc.
+# Copyright (C) 2014-2015 Red Hat, Inc.
 #
 # fedimg is free software: you can redistribute it and/or modify
 # it under the terms of the GNU Affero General Public License as
@@ -17,17 +17,20 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 # Authors:  David Gay <dgay@redhat.com>
+#           Ralph Bean <rbean@redhat.com>
 #
 
 """
 Utility functions for fedimg.
 """
 
+import functools
 import socket
 import subprocess
 
 import paramiko
 from libcloud.compute.types import Provider
+from libcloud.compute.providers import get_driver
 
 import fedimg
 
@@ -77,15 +80,8 @@ def virt_types_from_url(url):
 def region_to_provider(region):
     """ Takes a region name (ex. 'eu-west-1') and returns
     the appropriate libcloud provider value. """
-    providers = {'ap-northeast-1': Provider.EC2_AP_NORTHEAST,
-                 'ap-southeast-1': Provider.EC2_AP_SOUTHEAST,
-                 'ap-southeast-2': Provider.EC2_AP_SOUTHEAST2,
-                 'eu-west-1': Provider.EC2_EU_WEST,
-                 'sa-east-1': Provider.EC2_SA_EAST,
-                 'us-east-1': Provider.EC2_US_EAST,
-                 'us-west-1': Provider.EC2_US_WEST,
-                 'us-west-2': Provider.EC2_US_WEST_OREGON}
-    return providers[region]
+    cls = get_driver(Provider.EC2)
+    return functools.partial(cls, region=region)
 
 
 def ssh_connection_works(username, ip, keypath):


### PR DESCRIPTION
According to the libcloud docs, the way you're supposed to access these
provider/driver objects changed in 0.14.0 and this is the way you're
supposed to do it now.  I tested this method by hand and was able to
create and destroy a temporary keypair in the eu-central-1 region, so..
I think it should work.

Please eyeball for typos as I haven't been able to test the full fedimg
cycle yet.

See https://libcloud.readthedocs.org/en/latest/upgrade_notes.html#amazon-ec2-compute-driver-changes