### PR TITLE
Make the snapshots public so that AMIs can be copied to different accounts

### DIFF
--- a/fedimg/services/ec2.py
+++ b/fedimg/services/ec2.py
@@ -353,6 +353,11 @@ class EC2Service(object):
                                  if s.id == snap_id][0]
                 sleep(10)
 
+            # Make the snapshot public, so that the AMIs can be copied
+            driver.ex_modify_snapshot_attribute(self.snapshot, {
+                'CreateVolumePermission.Add.1.Group': 'all'
+            })
+
             log.info('Snapshot taken')
 
             # Delete the volume now that we've got the snapshot
@@ -412,7 +417,7 @@ class EC2Service(object):
                         architecture=self.image_arch))
                 except Exception as e:
                     # Check if the problem was a duplicate name
-                    if 'InvalidAMIName.Duplicate' in e.message:
+                    if 'InvalidAMIName.Duplicate' in str(e):
                         # Keep trying until an unused name is found
                         self.dup_count += 1
                         continue


### PR DESCRIPTION
This fixes the issues, BZ[1], Pagure[2] and uses the libcloud patch[3]. 

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1423753
[2] https://pagure.io/atomic-wg/issue/263
[3] https://github.com/apache/libcloud/pull/990

/cc @dustymabe

Signed-off-by: Sayan Chowdhury <sayan.chowdhury2012@gmail.com>