### PR TITLE
Remove duplicate image.upload fedmsg on AMI upload completion

### DIFF
--- a/fedimg/services/ec2/ec2imgpublisher.py
+++ b/fedimg/services/ec2/ec2imgpublisher.py
@@ -213,23 +213,6 @@ class EC2ImagePublisher(EC2Base):
                     )
                 )
 
-                fedimg.messenger.notify(
-                    topic='image.upload',
-                    msg=dict(
-                        image_name=get_image_name_from_ami_name_for_fedmsg(image.name),
-                        image_url=self.image_url,
-                        destination=self.region,
-                        service=self.service,
-                        status='completed',
-                        compose=self.compose_id,
-                        extra=dict(
-                            id=image.id,
-                            virt_type=virt_type,
-                            vol_type=volume_type
-                        )
-                    )
-                )
-
             published_images.append({
                 'image_id': image.id,
                 'is_image_public': is_image_public,


### PR DESCRIPTION
We already send image.upload fedmsg notification in
EC2ImageUploader::_register_image() method on an AMI
upload completion. Sending again same notification
on AMI getting published shouldn't be required.

Signed-off-by: Sinny Kumari <sinny@redhat.com>