### PR TITLE
Include AMIs to missing AWS ec2 regions

### DIFF
--- a/fedimg-conf.toml.example
+++ b/fedimg-conf.toml.example
@@ -13,7 +13,8 @@ base_region = 'us-east-1'
 bucket_name = 'fedora-s3-bucket-fedimg'
 regions = ['ap-northeast-2', 'us-east-2', 'ap-southeast-1', 'ap-southeast-2',
            'ap-south-1', 'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-2',
-           'us-gov-west-1', 'us-west-1', 'eu-central-1', 'ap-northeast-1']
+           'us-west-1', 'eu-central-1', 'ap-northeast-1', 'ca-central-1',
+           'eu-west-2', 'eu-west-3']
 
 [rackspace]
 username = "someuser"


### PR DESCRIPTION
Related - https://pagure.io/atomic-wg/issue/193

Also removed us-gov-west-1 from the list because 'aws ec2 describe-regions ' doesn't show this region listed.

Signed-off-by: Sinny Kumari <sinny@redhat.com>