### PR TITLE
Add basic Vagrant image for running unit test.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ fedimg.cfg
 
 # pytest
 *pytest_cache
+
+# vagrant
+.vagrant
+Vagrantfile

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ information.
 Official Fedimg documentation can be [found at
 RTFD](https://fedimg.readthedocs.org) or in `docs/`.
 
+If you are interested in contributing to fedimg, you can [read the developer documentation](https://github.com/fedora-infra/fedimg/tree/develop/docs/development).
+
 ## Triggering jobs
 
 Fedimg is designed to perform automatically when it sees the appropriate

--- a/devel/Vagrantfile.example
+++ b/devel/Vagrantfile.example
@@ -1,0 +1,68 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# On your host:
+# git clone https://github.com/fedora-infra/fedimg.git
+# cd fedimg
+# cp devel/Vagrantfile.example Vagrantfile
+# vagrant up
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+ config.vm.box_url = "https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-28-1.1.x86_64.vagrant-libvirt.box"
+ config.vm.box = "f28-cloud-libvirt"
+ config.vm.box_download_checksum = "d60f52c9cb04bfd4c5e950410611c746641f0b5f76830a53d44a0f1a43ab3fac"
+ config.vm.box_download_checksum_type = "sha256"
+
+ # This is an optional plugin that, if installed, updates the host's /etc/hosts
+ # file with the hostname of the guest VM. In Fedora it is packaged as
+ # ``vagrant-hostmanager``
+ if Vagrant.has_plugin?("vagrant-hostmanager")
+     config.hostmanager.enabled = true
+     config.hostmanager.manage_host = true
+ end
+
+ # Vagrant can share the source directory using rsync, NFS, or SSHFS (with the vagrant-sshfs
+ # plugin). Consult the Vagrant documentation if you do not want to use SSHFS.
+ config.vm.synced_folder ".", "/vagrant", disabled: true
+ config.vm.synced_folder ".", "/home/vagrant/fedimg", type: "sshfs", sshfs_opts_append: "-o nonempty"
+
+ # To cache update packages (which is helpful if frequently doing `vagrant destroy && vagrant up`)
+ # you can create a local directory and share it to the guest's DNF cache. Uncomment the lines below
+ # to create and use a dnf cache directory
+ #
+ # Dir.mkdir('.dnf-cache') unless File.exists?('.dnf-cache')
+ # config.vm.synced_folder ".dnf-cache", "/var/cache/dnf", type: "sshfs", sshfs_opts_append: "-o nonempty"
+
+ # Comment this line if you would like to disable the automatic update during provisioning
+ config.vm.provision "shell", inline: "sudo dnf upgrade -y"
+
+ # bootstrap and run with ansible
+ config.vm.provision "shell", inline: "sudo dnf -y install python2-dnf libselinux-python python3-tox"
+ config.vm.provision "shell", inline: "sudo dnf -y groupinstall 'C Development Tools and Libraries'"
+ config.vm.provision "shell", inline: "sudo mkdir -p /etc/fedimg && sudo cp /home/vagrant/fedimg/fedimg-conf.toml.example /etc/fedimg/fedimg-conf.toml"
+
+
+
+ # Create the fedimg dev box
+ config.vm.define "fedimg" do |fedimg|
+    fedimg.vm.host_name = "fedimg-dev.example.com"
+
+    fedimg.vm.provider :libvirt do |domain|
+        # Season to taste
+        domain.cpus = 2
+        domain.graphics_type = "spice"
+        domain.memory = 1024
+        domain.video_type = "qxl"
+
+        # Uncomment the following line if you would like to enable libvirt's unsafe cache
+        # mode. It is called unsafe for a reason, as it causes the virtual host to ignore all
+        # fsync() calls from the guest. Only do this if you are comfortable with the possibility of
+        # your development guest becoming corrupted (in which case you should only need to do a
+        # vagrant destroy and vagrant up to get a new one).
+        #
+        # domain.volume_cache = "unsafe"
+    end
+ end
+end

--- a/docs/development/installation.rst
+++ b/docs/development/installation.rst
@@ -2,6 +2,10 @@
 Development Guide
 =================
 
+A vagrant virtual machine is avalaible to make running the unit test easy. If you wish to use this virual machine as development environment
+you can check how to get started in the `testing documentation`_.
+
+
 Fedimg is application written in Python. It uses `libcloud`_ to connect with
 the external Cloud providers.
 
@@ -42,3 +46,4 @@ the external Cloud providers.
 Happy Hacking!
 
 .. _libcloud: https://libcloud.apache.org/
+.. _testing documentation:  https://github.com/fedora-infra/fedimg/blob/develop/docs/development/testing.rst

--- a/docs/development/testing.rst
+++ b/docs/development/testing.rst
@@ -8,6 +8,9 @@ package.
 Running the tests
 -----------------
 
+Virtualenv
+++++++++++
+
 Refer to the documentation to setup your virtualenv.
 
 #. Activate the virtualenv::
@@ -20,3 +23,33 @@ Refer to the documentation to setup your virtualenv.
     $ python setup.py test
 
 .. _pytest: https://pytest.org/
+
+
+Vagrant box
++++++++++++
+
+Vagrant allows contributors to get quickly up and running with a fedimg development environment by automatically configuring a virtual machine.
+To get started, simply use these commands::
+
+    $ sudo dnf install ansible libvirt vagrant-libvirt vagrant-sshfs
+    $ sudo systemctl enable libvirtd
+    $ sudo systemctl start libvirtd
+    $ git clone git@github.com:fedora-infra/fedimg.git
+    $ cd fedimg
+    $ cp devel/Vagrantfile.example Vagrantfile
+    $ vagrant up
+
+You can ssh into your running Vagrant box like this::
+
+    # Make sure your fedimg checkout is your shell's cwd
+    $ vagrant ssh
+
+The code from your development host will be mounted in ``/home/vagrant/fedimg``
+in the guest. You can edit this code on the host, and the vagrant-sshfs plugin will cause the
+changes to automatically be reflected in the guest's ``/home/vagrant/fedimg`` folder.
+
+Run the tests::
+
+    $ vagrant ssh
+    $ cd fedimg
+    $ tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,25 @@
+[tox]
+envlist = py27,lint
+
+[testenv]
+deps =
+    psutil
+    moksha
+    pytest
+    pytest-cov
+    mock
+    vcrpy
+# Substitute your test runner of choice
+commands =
+    py.test
+
+[testenv:lint]
+deps =
+    flake8
+commands =
+    python -m flake8 {posargs}
+
+[flake8]
+show-source = True
+max-line-length = 90
+exclude = .git,.tox,dist,*egg,tests


### PR DESCRIPTION
This commit adds a Vagrantfile example and the
tox.ini configuration needed to run the fedimg
unit test.

Signed-off-by: Clement Verna <cverna@tutanota.com>