### PR TITLE
Fix invalid parameter error when calling euca-import-volume command

### DIFF
--- a/fedimg/services/ec2/ec2imguploader.py
+++ b/fedimg/services/ec2/ec2imguploader.py
@@ -166,7 +166,7 @@ class EC2ImageUploader(EC2Base):
         if self.volume_via_s3:
             output, err, retcode = external_run_command([
                 'euca-import-volume',
-                source,
+                source[5:],
                 '-f',
                 self.image_format,
                 '--region',

--- a/fedimg/utils.py
+++ b/fedimg/utils.py
@@ -108,6 +108,8 @@ def get_value_from_dict(_dict, *keys):
 
 
 def external_run_command(command):
+    if command[0] == 'euca-import-volume':
+        os.chdir('/tmp')
     _log.info("Starting the command: %r" % command)
     ret = subprocess.Popen(' '.join(command), stdin=subprocess.PIPE,
                            shell=True, stdout=subprocess.PIPE,


### PR DESCRIPTION
## Changes description
`trigger_upload.py` wasn't working because when it calls `euca-import-volume`, that command was throwing an error about an invalid format of the manifest url when concatenating it with the path of the file.
This PR works around that problem because `euca-import-volume` works just fine when executed directly from `/tmp` directory.

Here is last lines of the log with those changes:
```
[2022-02-17 01:11:40][fedimg.services.ec2.ec2imgpublisher    INFO] Publish image (ami-0499d828467cb4cf1) in eu-west-2 started
[2022-02-17 01:11:40][fedimg.services.ec2.ec2imgpublisher    INFO] Publish image (ami-0499d828467cb4cf1) in eu-west-2 completed
[2022-02-17 01:11:40][fedimg.services.ec2.ec2imgpublisher    INFO] Publish snaphsot for image (ami-0499d828467cb4cf1) in eu-west-2 started
[2022-02-17 01:11:41][fedimg.services.ec2.ec2imgpublisher    INFO] Fetched snapshot for image (ami-0499d828467cb4cf1): snap-0bfc5543eb0cd474e
[2022-02-17 01:11:41][fedimg.services.ec2.ec2imgpublisher    INFO] Publish snaphsot for image (ami-0499d828467cb4cf1) in eu-west-2 completed
[2022-02-17 01:11:41][fedimg.uploader    INFO] AWS EC2Service process is completed.
```
## Related Issue
* Pagure fedora-infra [#10532](https://pagure.io/fedora-infrastructure/issue/10532)

Signed-off-by: Pedro Moura <pmoura@redhat.com>