### PR TITLE
EC2 AMIs default to the gp3 EBS volume type

### DIFF
--- a/docs/architecture/configuration.rst
+++ b/docs/architecture/configuration.rst
@@ -90,4 +90,11 @@ volume_size
 
 An integer, specifying the size of the volume to be created in GiB.
 
+.. _conf-volume-types:
+
+volume_types
+-----------
+
+A list containing all of the backing volume types the AMIs would be registered against, each of which differ in performance characteristics and price.
+
 .. _worker process: https://docs.python.org/2/library/multiprocessing.html#using-a-pool-of-workers

--- a/docs/services/ec2.md
+++ b/docs/services/ec2.md
@@ -18,7 +18,7 @@ potentially six different AMIs for each Fedora Cloud image processed.
 </table>
 `*`: Not yet added to Fedimg
 
-*The "2 volume types" mentioned in this table are Standard and GP2. GP2 is a new
+*The "2 volume types" mentioned in this table are Standard and GP3. GP3 is a new
 SSD-based type Amazon is encouraging. It has different pricing and performance
 characteristics.*
 
@@ -57,7 +57,7 @@ When the uploader calls on the EC2 service, the following happens:
     subsequently destroyed.
 
 4.  The volume snapshot is used to register the image as an AMI. Images
-    are registered with both standard and GP2 volume types, as well as
+    are registered with both standard and GP3 volume types, as well as
     with both paravirtual and HVM virtualization.
 
 5.  The utility instance is shut down, and a test instance is started,

--- a/fedimg-conf.toml.example
+++ b/fedimg-conf.toml.example
@@ -10,7 +10,7 @@ access_id = "secretaccessID"
 secret_key = "supersecretsecretkey"
 base_region = 'us-east-1'
 bucket_name = 'fedora-s3-bucket-fedimg'
-volume_types = ['standard', 'gp2']
+volume_types = ['standard', 'gp3']
 regions = ['ap-northeast-2', 'us-east-2', 'ap-southeast-1', 'ap-southeast-2',
            'ap-south-1', 'eu-west-1', 'sa-east-1', 'us-east-1', 'us-west-2',
            'us-west-1', 'eu-central-1', 'ap-northeast-1', 'ca-central-1',

--- a/fedimg/services/ec2/ec2imguploader.py
+++ b/fedimg/services/ec2/ec2imguploader.py
@@ -67,7 +67,7 @@ class EC2ImageUploader(EC2Base):
             'image_virtualization_type': 'hvm',
             'image_architecture': 'x86_64',
             'image_url': None,
-            'image_volume_type': 'gp2',
+            'image_volume_type': 'gp3',
             'image_format': 'raw',
             'region': None,
             'service': 'EC2',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -277,7 +277,7 @@ class TestFedimgUtils(unittest.TestCase):
         mock_image.extra = {
             'block_device_mapping': [{
                 'ebs': {
-                    'volume_type': 'gp2'
+                    'volume_type': 'gp3'
                 }
             }]
         }
@@ -286,7 +286,7 @@ class TestFedimgUtils(unittest.TestCase):
         volume_type = fedimg.utils.get_volume_type_from_image(
                 mock_image, region)
 
-        assert volume_type == 'gp2'
+        assert volume_type == 'gp3'
 
     def test_get_virt_type_from_image_hvm(self):
         mock_image = mock.Mock()
@@ -336,10 +336,10 @@ class TestFedimgUtils(unittest.TestCase):
             'hvm',
             'us-east-1',
             '0',
-            'gp2'
+            'gp3'
         )
 
-        assert image_name == 'Fedora-Atomic-26-1.5.x86_64-hvm-us-east-1-gp2-0'
+        assert image_name == 'Fedora-Atomic-26-1.5.x86_64-hvm-us-east-1-gp3-0'
 
     def test_get_image_name_from_image_without_vol_type(self):
         image_name = fedimg.utils.get_image_name_from_image(
@@ -353,15 +353,15 @@ class TestFedimgUtils(unittest.TestCase):
 
     def test_get_image_name_from_ami_name(self):
         image_name = fedimg.utils.get_image_name_from_ami_name(
-            'Fedora-Cloud-Base-26-20180329.0.x86_64-paravirtual-us-east-1-gp2-0',
+            'Fedora-Cloud-Base-26-20180329.0.x86_64-paravirtual-us-east-1-gp3-0',
             'eu-west-1'
         )
 
-        assert image_name == 'Fedora-Cloud-Base-26-20180329.0.x86_64-paravirtual-eu-west-1-gp2-0'
+        assert image_name == 'Fedora-Cloud-Base-26-20180329.0.x86_64-paravirtual-eu-west-1-gp3-0'
 
     def test_get_image_name_from_ami_name_for_fedmsg(self):
         image_name = fedimg.utils.get_image_name_from_ami_name_for_fedmsg(
-            'Fedora-Cloud-Base-26-20180329.0.x86_64-paravirtual-us-east-1-gp2-0',
+            'Fedora-Cloud-Base-26-20180329.0.x86_64-paravirtual-us-east-1-gp3-0',
         )
 
         assert image_name == 'Fedora-Cloud-Base-26-20180329.0.x86_64'


### PR DESCRIPTION
This PR is to change the default volume type for EC2 AMIs created for the Fedora Cloud SIG.  These should make images cheaper, has better performance, and it boots faster. [This change](https://fedoraproject.org/wiki/Changes/CloudEC2gp3) is slated for F39.

The PR includes updates to the default settings, the configuration example, the tests, and the documentation.

FESCo issue: [#2974](https://pagure.io/fesco/issue/2974)